### PR TITLE
If curl is not installed build script fails on Chrome OS Fonts install

### DIFF
--- a/crbuild/vm-setup.sh
+++ b/crbuild/vm-setup.sh
@@ -75,6 +75,9 @@ fi
 # Subversion and git-svn.
 sudo apt-get install -y git-svn subversion
 
+# curl is needed for Chrome OS fonts
+sudo apt-get install curl
+
 # Chromium source.
 # https://code.google.com/p/chromium/wiki/UsingGit
 # http://dev.chromium.org/developers/how-tos/get-the-code


### PR DESCRIPTION
Here's the python traceback you'll get if curl is not installed:

``` sh
Installing Chrome OS fonts to /usr/local/share/fonts/chromeos.
Traceback (most recent call last):
  File "build/linux/install-chromeos-fonts.py", line 79, in <module>
    sys.exit(main(sys.argv[1:]))
  File "build/linux/install-chromeos-fonts.py", line 56, in main
    subprocess.check_call(['curl', '-L', url, '-o', tarball])
  File "/usr/lib/python2.7/subprocess.py", line 506, in check_call
    retcode = call(*popenargs, **kwargs)
  File "/usr/lib/python2.7/subprocess.py", line 493, in call
    return Popen(*popenargs, **kwargs).wait()
  File "/usr/lib/python2.7/subprocess.py", line 679, in __init__
    errread, errwrite)
  File "/usr/lib/python2.7/subprocess.py", line 1259, in _execute_child
    raise child_exception
OSError: [Errno 2] No such file or directory
```
