### PR TITLE
The ARM cross toolchain is only available on Ubuntu precise

### DIFF
--- a/crbuild/vm-build.md
+++ b/crbuild/vm-build.md
@@ -13,8 +13,8 @@ and building the files used in this library.
 
 These are the manual steps for setting up a VM. They only need to be done once.
 
-1. Get the 64-bit ISO for Ubuntu Server 12.10.
-    * Go to http://releases.ubuntu.com/12.10/
+1. Get the 64-bit ISO for Ubuntu Server precise (12.04*).
+    * Go to http://releases.ubuntu.com/precise/
     * Get the `64-bit PC (AMD64) server install image`
 
 2. Set up a VirtualBox VM.


### PR DESCRIPTION
The docs say to go get Ubuntu 12.10 (quantal), which I did, and then I hit this way down in the Google build scripts:

`ERROR: Installing the ARM cross toolchain is only available on Ubuntu precise`

So, I'm updating the docs to _not_ recommend using 12.10 -- unless there is some workaround for this I don't know about?
